### PR TITLE
[server] Add server-side cursor support

### DIFF
--- a/server/src/cursors/error.rs
+++ b/server/src/cursors/error.rs
@@ -1,0 +1,60 @@
+use std::error::Error;
+use std::fmt;
+use tokio::sync::watch;
+
+use crate::cursors::map::CursorsMap;
+use crate::cursors::map::CursorsMapIndex;
+
+/// This is an ugly wrapper around `watch::error::SendError<CursorsMap>` to avoid leaking CursorMap
+/// as a public type since enum fields are always public.
+#[derive(Debug)]
+pub struct WatchSendErrorWrapper(pub(super) watch::error::SendError<CursorsMap>);
+
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum CursorUpdateError {
+    Full,
+    // This shouldn't be possible since Arc<CursorsInner> holds onto tx and rx, so the
+    // channel can't close until CursorInner is dropped.
+    Notify(WatchSendErrorWrapper),
+    // LockError is caused by a PoisonError, but retaining the PoisonError is too tricky because it
+    // holds the lock's guard (and it's associated lifetime).
+    Lock,
+    // The CursorsMapIndex used on this map is bad. Either it's stale or an index for another map.
+    InvalidIndex(CursorsMapIndex),
+}
+
+impl fmt::Display for CursorUpdateError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Full => write!(f, "Attempted to insert into a full cursor map"),
+            Self::Notify(WatchSendErrorWrapper(err)) => {
+                write!(f, "Failed to notify cursor receivers: {}", err)
+            }
+            Self::Lock => write!(f, "Failed to acquire a cursor write lock."),
+            Self::InvalidIndex(idx) => write!(f, "Cursor index {:?} is invalid for the map.", idx),
+        }
+    }
+}
+
+impl Error for CursorUpdateError {}
+
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum CursorReceiveError {
+    // This shouldn't be possible since Arc<CursorsInner> holds onto tx and rx.
+    Notify,
+    // LockError is caused by a PoisonError.
+    Lock,
+}
+
+impl fmt::Display for CursorReceiveError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Notify => write!(f, "Tried to recv, but the watch channel was closed."),
+            Self::Lock => write!(f, "Failed to acquire a cursor read lock."),
+        }
+    }
+}
+
+impl Error for CursorReceiveError {}

--- a/server/src/cursors/map.rs
+++ b/server/src/cursors/map.rs
@@ -1,0 +1,163 @@
+use serde::ser::{Serialize, SerializeMap, Serializer};
+
+use crate::cursors::error::CursorUpdateError;
+use crate::cursors::selection::CursorSelection;
+use crate::room::MAX_SESSIONS_PER_ROOM;
+
+type SessionId = u64;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CursorsMapIndex(usize);
+
+// This needs to be relatively cheap to copy so that we can reasonably debounce and then compare
+// (for equality) the results we send to the client.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct CursorsMap {
+    // MAX_SESSIONS_PER_ROOM is small, so don't use a real map or even waste a heap allocation on a
+    // Vec.
+    //
+    // We need to make sure that the iteration order is the same every time so that equality works.
+    // Since the entry lives as long as the SessionId does, we don't need to worry about
+    // insert/removal changing order.
+    inner: [Option<(SessionId, CursorSelection)>; MAX_SESSIONS_PER_ROOM],
+}
+
+impl CursorsMap {
+    pub fn new() -> Self {
+        CursorsMap {
+            inner: Default::default(),
+        }
+    }
+
+    pub fn new_session(
+        &mut self,
+        session_id: SessionId,
+    ) -> Result<CursorsMapIndex, CursorUpdateError> {
+        let mut idx = None;
+        // find a free slot and pick that idx
+        for (iter_idx, entry) in self.inner.iter().enumerate() {
+            if entry.is_none() {
+                idx = Some(iter_idx);
+                break;
+            }
+        }
+        match idx {
+            Some(idx) => {
+                self.inner[idx] = Some((session_id, CursorSelection::new()));
+                Ok(CursorsMapIndex(idx))
+            }
+            None => Err(CursorUpdateError::Full),
+        }
+    }
+
+    pub fn update(
+        &mut self,
+        idx: CursorsMapIndex,
+        selection: CursorSelection,
+    ) -> Result<(), CursorUpdateError> {
+        if let Some(ref mut entry) = self.inner[idx.0] {
+            entry.1 = selection;
+            Ok(())
+        } else {
+            Err(CursorUpdateError::InvalidIndex(idx))
+        }
+    }
+
+    pub fn remove(&mut self, idx: CursorsMapIndex) -> Result<(), CursorUpdateError> {
+        let entry = &mut self.inner[idx.0];
+        if entry.is_some() {
+            *entry = None;
+            Ok(())
+        } else {
+            Err(CursorUpdateError::InvalidIndex(idx))
+        }
+    }
+
+    pub fn into_view(self, idx: CursorsMapIndex) -> CursorsMapView {
+        CursorsMapView { map: self, idx }
+    }
+}
+
+pub struct CursorsMapView {
+    pub(super) map: CursorsMap,
+    pub(super) idx: CursorsMapIndex,
+}
+
+impl Serialize for CursorsMapView {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        // we can compute size, but not without keeping a counter in CursorsMap or traversing the
+        // map twice, and serde_json probably doesn't get much benefit from a size.
+        let mut s_map = serializer.serialize_map(None)?;
+        for (idx, entry) in self.map.inner.iter().enumerate() {
+            if idx != self.idx.0 {
+                if let Some((_k, v)) = entry {
+                    if !v.is_empty() {
+                        s_map.serialize_entry(&idx, v)?;
+                    }
+                }
+            }
+        }
+        s_map.end()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn test_empty_view() {
+        let mut map = CursorsMap::new();
+        let idx = map.new_session(1234).unwrap();
+        assert_eq!(
+            serde_json::to_value(&map.into_view(idx)).unwrap(),
+            json!({}),
+        );
+    }
+
+    #[test]
+    fn test_two_clients() {
+        let mut map = CursorsMap::new();
+        let idx0 = map.new_session(1234).unwrap();
+        let idx1 = map.new_session(4321).unwrap();
+        map.update(
+            idx0,
+            serde_json::from_value::<CursorSelection>(json!([1, 2, 3])).unwrap(),
+        )
+        .unwrap();
+        map.update(
+            idx1,
+            serde_json::from_value::<CursorSelection>(json!([4, 5, 6])).unwrap(),
+        )
+        .unwrap();
+        // the view for idx0 shows the results for idx1
+        assert_eq!(
+            serde_json::to_value(&map.clone().into_view(idx0)).unwrap(),
+            json!({"1": [4, 5, 6]}),
+        );
+        // and the view for idx1 shows the results for idx0
+        assert_eq!(
+            serde_json::to_value(&map.clone().into_view(idx1)).unwrap(),
+            json!({"0": [1, 2, 3]}),
+        );
+    }
+
+    #[test]
+    fn test_full_map() {
+        let mut map = CursorsMap::new();
+        let valid_sessions: Vec<CursorsMapIndex> = (0..MAX_SESSIONS_PER_ROOM)
+            .map(|session_id| map.new_session(session_id as SessionId).unwrap())
+            .collect();
+        assert!(matches!(
+            map.new_session(1000),
+            Err(CursorUpdateError::Full)
+        ));
+
+        // if we remove an entry from a full map and then call new_session, we get the index we
+        // just removed
+        map.remove(valid_sessions[0]).unwrap();
+        assert_eq!(map.new_session(1000).unwrap(), valid_sessions[0],);
+    }
+}

--- a/server/src/cursors/mod.rs
+++ b/server/src/cursors/mod.rs
@@ -1,0 +1,148 @@
+//! Exposes an API that wraps over [tokio::sync::watch] to share a map of cursor selections for
+//! every client in the room.
+//!
+//! The underlying map is stored compactly on the stack using bitmasks, so cloning the resulting
+//! value around is cheap-ish.
+
+mod error;
+mod map;
+mod selection;
+
+use log::error;
+use std::sync::{Arc, Mutex};
+use tokio::sync::watch;
+
+use crate::cursors::error::WatchSendErrorWrapper;
+pub use crate::cursors::error::{CursorReceiveError, CursorUpdateError};
+pub use crate::cursors::map::CursorsMapView;
+use crate::cursors::map::{CursorsMap, CursorsMapIndex};
+pub use crate::cursors::selection::CursorSelection;
+
+type SessionId = u64;
+
+pub struct Cursors {
+    inner: Arc<CursorsInner>,
+}
+
+impl Cursors {
+    pub fn new() -> Self {
+        let (tx, rx) = watch::channel(CursorsMap::new());
+        Cursors {
+            inner: Arc::new(CursorsInner {
+                tx: Mutex::new(tx),
+                rx,
+            }),
+        }
+    }
+
+    pub fn new_session(&self, session_id: SessionId) -> Result<SessionCursor, CursorUpdateError> {
+        let map_idx = self.inner.apply(|map| map.new_session(session_id))?;
+        Ok(SessionCursor {
+            tx: SessionCursorSender {
+                cursors_inner: self.inner.clone(),
+                map_idx,
+            },
+            rx: SessionCursorReceiver {
+                map_idx,
+                rx: self.inner.rx.clone(),
+            },
+        })
+    }
+}
+
+struct CursorsInner {
+    tx: Mutex<watch::Sender<CursorsMap>>,
+    rx: watch::Receiver<CursorsMap>,
+}
+
+impl CursorsInner {
+    fn apply<F, R>(&self, operation: F) -> Result<R, CursorUpdateError>
+    where
+        F: Fn(&mut CursorsMap) -> Result<R, CursorUpdateError>,
+    {
+        let mut map = self.rx.borrow().clone();
+        let ret = operation(&mut map)?;
+        self.tx
+            .lock()
+            .or(Err(CursorUpdateError::Lock))?
+            .broadcast(map)
+            .map_err(|send_err| CursorUpdateError::Notify(WatchSendErrorWrapper(send_err)))?;
+        Ok(ret)
+    }
+}
+
+pub struct SessionCursor {
+    pub tx: SessionCursorSender,
+    pub rx: SessionCursorReceiver,
+}
+
+pub struct SessionCursorSender {
+    cursors_inner: Arc<CursorsInner>,
+    map_idx: CursorsMapIndex,
+}
+
+pub struct SessionCursorReceiver {
+    map_idx: CursorsMapIndex,
+    rx: watch::Receiver<CursorsMap>,
+}
+
+impl SessionCursorSender {
+    pub fn update(&self, selection: CursorSelection) -> Result<(), CursorUpdateError> {
+        self.cursors_inner
+            .apply(|map| map.update(self.map_idx, selection))
+    }
+}
+
+impl SessionCursorReceiver {
+    /// Waits until somebody calls `update`, then clones the map and returns a CursorsMapView.
+    ///
+    /// The first time this is called, it returns immediately with the current value.
+    pub async fn recv(&mut self) -> Result<CursorsMapView, CursorReceiveError> {
+        let map = self.rx.recv().await.ok_or(CursorReceiveError::Notify)?;
+        Ok(map.into_view(self.map_idx))
+    }
+}
+
+impl Drop for SessionCursorSender {
+    fn drop(&mut self) {
+        if let Err(err) = self.cursors_inner.apply(|map| map.remove(self.map_idx)) {
+            error!(
+                "Got an non-fatal error while dropping SessionCursorSender. \
+                This should not happen. {}",
+                err
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_two_clients() {
+        let cursors = Cursors::new();
+
+        let mut session0 = cursors.new_session(1000).unwrap();
+        // we can recv immediately on a new session
+        assert_eq!(
+            serde_json::to_value(session0.rx.recv().await.unwrap()).unwrap(),
+            json!({})
+        );
+
+        let mut session1 = cursors.new_session(1001).unwrap();
+
+        session0.tx.update(serde_json::from_value(json!([1, 2, 3])).unwrap()).unwrap();
+        session1.tx.update(serde_json::from_value(json!([4, 5, 6])).unwrap()).unwrap();
+        assert_eq!(
+            serde_json::to_value(session0.rx.recv().await.unwrap()).unwrap(),
+            json!({"1": [4, 5, 6]})
+        );
+        assert_eq!(
+            serde_json::to_value(session1.rx.recv().await.unwrap()).unwrap(),
+            json!({"0": [1, 2, 3]})
+        );
+    }
+}

--- a/server/src/cursors/selection.rs
+++ b/server/src/cursors/selection.rs
@@ -1,0 +1,136 @@
+use serde::de::{self, Deserialize, Deserializer, SeqAccess, Unexpected, Visitor};
+use serde::ser::{self, Serialize, SerializeSeq, Serializer};
+use std::fmt;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CursorSelection {
+    // there are 81 squares, so we can cram all of them into a u128
+    square_bit_flags: u128,
+}
+
+impl CursorSelection {
+    pub fn new() -> Self {
+        CursorSelection {
+            square_bit_flags: 0,
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.square_bit_flags == 0
+    }
+}
+
+impl Serialize for CursorSelection {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        if self.square_bit_flags >> 81 != 0 {
+            return Err(ser::Error::custom(
+                "CursorSelection contains an invalid high bit",
+            ));
+        }
+        let sbf = self.square_bit_flags;
+        let len = sbf.count_ones() as usize;
+        let mut seq = serializer.serialize_seq(Some(len))?;
+        if len == 0 {
+            return seq.end();
+        }
+        for i in 0..81 {
+            if (1 << i) & sbf != 0 {
+                seq.serialize_element(&i)?;
+            }
+        }
+        seq.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for CursorSelection {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        deserializer.deserialize_seq(CursorSelectionVisitor)
+    }
+}
+
+struct CursorSelectionVisitor;
+
+impl<'de> Visitor<'de> for CursorSelectionVisitor {
+    type Value = CursorSelection;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("an sequence of unsigned integer indexes less than 81")
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let mut square_bit_flags = 0;
+        while let Some(el) = seq.next_element::<u8>()? {
+            if el < 81 {
+                square_bit_flags |= 1 << el;
+            } else {
+                return Err(de::Error::invalid_value(
+                    Unexpected::Unsigned(el.into()),
+                    &"an unsigned integer index less than 81",
+                ));
+            }
+        }
+        Ok(CursorSelection { square_bit_flags })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn test_serialize() {
+        assert_eq!(
+            serde_json::to_value(&CursorSelection {
+                square_bit_flags: 0
+            })
+            .unwrap(),
+            json!([])
+        );
+        assert_eq!(
+            serde_json::to_value(&CursorSelection {
+                square_bit_flags: 0b10101
+            })
+            .unwrap(),
+            json!([0, 2, 4])
+        );
+        assert_eq!(
+            serde_json::to_value(&CursorSelection {
+                square_bit_flags: 1 << 80
+            })
+            .unwrap(),
+            json!([80])
+        );
+        assert!(serde_json::to_value(&CursorSelection {
+            square_bit_flags: 1 << 81
+        })
+        .is_err());
+    }
+
+    #[test]
+    fn test_deserialize() {
+        assert_eq!(
+            serde_json::from_value::<CursorSelection>(json!([])).unwrap(),
+            CursorSelection {
+                square_bit_flags: 0
+            },
+        );
+        assert_eq!(
+            serde_json::from_value::<CursorSelection>(json!([0, 2, 4])).unwrap(),
+            CursorSelection {
+                square_bit_flags: 0b10101
+            },
+        );
+        assert_eq!(
+            serde_json::from_value::<CursorSelection>(json!([80])).unwrap(),
+            CursorSelection {
+                square_bit_flags: 1 << 80
+            },
+        );
+        assert!(serde_json::from_value::<CursorSelection>(json!([81])).is_err());
+    }
+}

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -3,6 +3,7 @@ use std::error::Error;
 use std::fmt;
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum SudokuError {
     InvalidSquareIndex(usize),
     ReceivedBinaryMessage,
@@ -53,3 +54,5 @@ impl Serialize for SudokuError {
         serializer.serialize_str(&self.to_string())
     }
 }
+
+impl Error for SudokuError {}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,14 +1,16 @@
 mod board;
+mod cursors;
 mod digit;
 mod error;
 mod room;
 
+use futures::prelude::*;
 use futures::stream::{SplitSink, SplitStream};
-use futures::{SinkExt, StreamExt};
 use log::{debug, error, info, warn};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::error::Error;
+use std::fmt;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::broadcast;
@@ -17,6 +19,9 @@ use warp::ws::{Message, WebSocket};
 use warp::Filter;
 
 use crate::board::{BoardDiff, BoardDiffOperation, BoardState};
+use crate::cursors::{
+    CursorReceiveError, CursorSelection, CursorsMapView, SessionCursor, SessionCursorSender,
+};
 use crate::digit::Digit;
 use crate::error::SudokuError;
 use crate::room::{BoardDiffBroadcast, ClientSyncId, RoomId, RoomState, Session, SessionId};
@@ -35,18 +40,19 @@ enum ResponseMessage {
         diffs: Vec<BoardDiff>,
     },
     /// Sent when the client falls too far behind (RecvError::Lagged)
-    #[allow(dead_code)]
     #[serde(rename_all = "camelCase")]
     FullUpdate {
         sync_id: Option<ClientSyncId>,
         board_state: BoardState,
     },
     #[serde(rename_all = "camelCase")]
+    UpdateCursor { map: CursorsMapView },
+    #[serde(rename_all = "camelCase")]
     Error { message: SudokuError },
 }
 
 impl From<SudokuError> for ResponseMessage {
-    fn from(err: SudokuError) -> ResponseMessage {
+    fn from(err: SudokuError) -> Self {
         ResponseMessage::Error { message: err }
     }
 }
@@ -61,6 +67,8 @@ enum RequestMessage {
         sync_id: ClientSyncId,
         diffs: Vec<BoardDiff>,
     },
+    #[serde(rename_all = "camelCase")]
+    UpdateCursor { selection: CursorSelection },
 }
 
 #[derive(Default)]
@@ -74,6 +82,7 @@ async fn handle_request_message(
     session_id: SessionId,
     req: RequestMessage,
     last_received_sync_id: &Mutex<Option<ClientSyncId>>,
+    cursor_tx: &SessionCursorSender,
 ) -> Option<ResponseMessage> {
     match req {
         RequestMessage::SetBoardState { board_state } => {
@@ -90,6 +99,17 @@ async fn handle_request_message(
                 None
             }
         }
+        RequestMessage::UpdateCursor { selection } => {
+            if let Err(err) = cursor_tx.update(selection) {
+                // this should never happen
+                error!("{}", err);
+                Some(ResponseMessage::Error {
+                    message: SudokuError::Internal(Box::new(err)),
+                })
+            } else {
+                None
+            }
+        }
     }
 }
 
@@ -98,12 +118,20 @@ async fn handle_web_socket_message(
     session_id: SessionId,
     ws_message: &Message,
     last_received_sync_id: &Mutex<Option<ClientSyncId>>,
+    cursor_tx: &SessionCursorSender,
 ) -> Option<ResponseMessage> {
     if let Ok(body) = ws_message.to_str() {
         debug!("received text messsage from client: {}", body);
         match serde_json::from_str::<RequestMessage>(body) {
             Ok(req) => {
-                handle_request_message(room_state, session_id, req, last_received_sync_id).await
+                handle_request_message(
+                    room_state,
+                    session_id,
+                    req,
+                    last_received_sync_id,
+                    cursor_tx,
+                )
+                .await
             }
             Err(err) => Some(SudokuError::SerdeJson(err).into()),
         }
@@ -163,11 +191,17 @@ async fn handle_realtime_api(ws: WebSocket, room_state: Arc<Mutex<RoomState>>) {
     let Session {
         session_id,
         mut diff_rx,
+        cursor: SessionCursor {
+            tx: cursor_tx,
+            rx: mut cursor_rx,
+        },
     } = match room_state.lock().await.new_session() {
         Ok(session) => session,
         Err(err) => {
-            let _possible_error =
-                write_response_to_socket(&ws_tx, ResponseMessage::from(err)).await;
+            let response_result = serialize_response(ResponseMessage::from(err));
+            if let Ok(response) = response_result {
+                let _possible_error = write_to_socket(&ws_tx, response).await;
+            }
             close_websocket(ws_tx, ws_rx).await;
             return;
         }
@@ -176,17 +210,20 @@ async fn handle_realtime_api(ws: WebSocket, room_state: Arc<Mutex<RoomState>>) {
     let last_sent_sync_id: Arc<Mutex<Option<ClientSyncId>>> = Arc::new(Mutex::new(None));
 
     debug!("sending init message to client");
-    let init_msg = {
-        // release the lock as soon as the message is constructed, before we send it
-        let rs = room_state.lock().await;
-        ResponseMessage::Init {
-            room_id: rs.room_id.to_string(),
-            // It's expensive, but clone this so we don't have to keep holding onto the lock.
-            // Maybe this could be an Arc<Cow<>>.
-            board_state: rs.board.clone(),
-        }
-    };
-    let write_result = write_response_to_socket(&ws_tx, init_msg).await;
+    let write_result = async {
+        let init_msg = {
+            // release the lock as soon as the message is constructed, before we send it
+            let rs = room_state.lock().await;
+            ResponseMessage::Init {
+                room_id: rs.room_id.to_string(),
+                // It's expensive, but clone this so we don't have to keep holding onto the lock.
+                // Maybe this could be an Arc<Cow<>>.
+                board_state: rs.board.clone(),
+            }
+        };
+        write_to_socket(&ws_tx, serialize_response(init_msg)?).await
+    }
+    .await;
 
     if write_result.is_err() {
         debug!("failed to send init message, so closing socket instead");
@@ -209,23 +246,25 @@ async fn handle_realtime_api(ws: WebSocket, room_state: Arc<Mutex<RoomState>>) {
                     }
                 };
                 if request.is_close() {
-                    return;
+                    return Ok(());
                 }
                 let response = handle_web_socket_message(
                     room_state.clone(),
                     session_id,
                     &request,
                     &last_received_sync_id,
+                    &cursor_tx,
                 )
                 .await;
-                if write_response_to_socket(&ws_tx, response).await.is_err() {
-                    break;
+                if let Some(response) = response {
+                    write_to_socket(&ws_tx, serialize_response(response)?).await?;
                 }
             }
+            Result::<(), ApiTaskError>::Ok(())
         }
     };
 
-    let broadcast_receiver = {
+    let diff_broadcast_receiver = {
         let ws_tx = ws_tx.clone();
         let last_received_sync_id = last_received_sync_id.clone();
         let last_sent_sync_id = last_sent_sync_id.clone();
@@ -234,7 +273,7 @@ async fn handle_realtime_api(ws: WebSocket, room_state: Arc<Mutex<RoomState>>) {
             loop {
                 let diff_broadcast = diff_rx.recv().await;
                 if let Err(broadcast::RecvError::Closed) = diff_broadcast {
-                    return;
+                    return Result::<(), ApiTaskError>::Ok(());
                 }
                 let response = handle_diff_broadcast(
                     &room_state,
@@ -245,40 +284,129 @@ async fn handle_realtime_api(ws: WebSocket, room_state: Arc<Mutex<RoomState>>) {
                     &last_sent_sync_id,
                 )
                 .await;
-                if write_response_to_socket(&ws_tx, response).await.is_err() {
-                    break;
-                }
+                write_to_socket(&ws_tx, serialize_response(response)?).await?;
             }
         }
     };
 
-    tokio::select! {
-        () = request_receiver => {},
-        () = broadcast_receiver => {},
+    let cursor_notify_receiver = {
+        let ws_tx = ws_tx.clone();
+        async move {
+            loop {
+                let cursor_map_view = cursor_rx.recv().await?;
+                let response = ResponseMessage::UpdateCursor {
+                    map: cursor_map_view,
+                };
+                write_to_socket(&ws_tx, serialize_response(response)?).await?;
+            }
+        }
     };
+
+    let result = tokio::select! {
+        r = request_receiver => r,
+        r = diff_broadcast_receiver => r,
+        r = cursor_notify_receiver => r,
+    };
+
+    match result {
+        Err(err) => match err {
+            // use a nested match because Result doesn't implement Display
+            ApiTaskError::CursorReceive(_) => {
+                error!("{}", err);
+            }
+            ApiTaskError::SocketWrite(SocketWriteError::Serialization(_)) => {
+                error!("{}", err);
+            }
+            ApiTaskError::SocketWrite(SocketWriteError::Warp(_)) => {
+                // this is probably just a network issue, so use a lower severity
+                warn!("{}", err);
+            }
+        },
+        Ok(_) => {}
+    }
 
     close_websocket(ws_tx, ws_rx).await;
 }
 
-async fn write_response_to_socket<R: Into<Option<ResponseMessage>>>(
-    ws_tx: &Mutex<SplitSink<WebSocket, Message>>,
-    msg: R,
-) -> Result<(), Box<dyn Error + Sync + Send>> {
-    if let Some(msg) = msg.into() {
-        let response_str = serde_json::to_string(&msg).map_err(|err| {
-            error!("failed to serialize response: {}", err);
+#[derive(Debug)]
+enum ApiTaskError {
+    CursorReceive(CursorReceiveError),
+    SocketWrite(SocketWriteError),
+}
+
+impl fmt::Display for ApiTaskError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::CursorReceive(err) => write!(f, "{}", err),
+            Self::SocketWrite(err) => write!(f, "{}", err),
+        }
+    }
+}
+
+impl Error for ApiTaskError {}
+
+impl From<CursorReceiveError> for ApiTaskError {
+    fn from(err: CursorReceiveError) -> Self {
+        Self::CursorReceive(err)
+    }
+}
+
+impl From<SocketWriteError> for ApiTaskError {
+    fn from(err: SocketWriteError) -> Self {
+        Self::SocketWrite(err)
+    }
+}
+
+#[derive(Debug)]
+enum SocketWriteError {
+    Serialization(serde_json::Error),
+    Warp(warp::Error),
+}
+
+impl fmt::Display for SocketWriteError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let err: Box<&dyn Error> = match self {
+            Self::Serialization(err) => Box::new(err),
+            Self::Warp(err) => Box::new(err),
+        };
+        write!(
+            f,
+            "Error occured while attempting to write to socket: {}",
             err
-        })?;
-        debug!("sending response to client: {}", response_str);
-        ws_tx
-            .lock()
-            .await
-            .send(Message::text(response_str))
-            .await
-            .map_err(|err| {
-                warn!("got an error upon writing to socket: {}", err);
-                err
-            })?;
+        )
+    }
+}
+
+impl Error for SocketWriteError {}
+
+impl From<serde_json::Error> for SocketWriteError {
+    fn from(err: serde_json::Error) -> Self {
+        Self::Serialization(err)
+    }
+}
+
+impl From<warp::Error> for SocketWriteError {
+    fn from(err: warp::Error) -> Self {
+        Self::Warp(err)
+    }
+}
+
+fn serialize_response(msg: ResponseMessage) -> Result<Message, SocketWriteError> {
+    let text = serde_json::to_string(&msg)?;
+    Ok(Message::text(text))
+}
+
+// You must serialize the response before passing it into this function because ResponseMessage is
+// not Send.
+async fn write_to_socket(
+    ws_tx: &Mutex<SplitSink<WebSocket, Message>>,
+    msg: Message,
+) -> Result<(), SocketWriteError> {
+    if let Some(msg) = msg.into() {
+        if let Ok(msg_text) = msg.to_str() {
+            debug!("sending response to client: {}", msg_text);
+        }
+        ws_tx.lock().await.send(msg).await?;
     }
     Ok(())
 }

--- a/src/gameLogic/RemoteGameState.ts
+++ b/src/gameLogic/RemoteGameState.ts
@@ -43,10 +43,15 @@ type FullUpdateResponseMessage = {
   syncId: number;
   boardState: ServerBoardState;
 };
+type UpdateCursorResponseMessage = {
+  type: "updateCursor";
+  map: {[colorIdx: string]: number[]};
+};
 type ResponseMessage =
   | InitResponseMessage
   | PartialUpdateResponseMessage
-  | FullUpdateResponseMessage;
+  | FullUpdateResponseMessage
+  | UpdateCursorResponseMessage;
 
 function toLocalBoardState(serverBs: ServerBoardState): LocalBoardState {
   return new LocalBoardState(
@@ -105,6 +110,7 @@ export default class RemoteGameState extends BaseGameState {
     roomId?: string | null,
     initialBoard?: LocalBoardState | null
   ): Promise<void> {
+    console.log("connect");
     const ws = new WebSocket(getUri(roomId));
     this.ws = ws;
     return new Promise((resolve, reject) => {
@@ -168,9 +174,12 @@ export default class RemoteGameState extends BaseGameState {
         this.clientBoardState = this.serverBoardState;
         this.updateClientBoardState(msg.syncId);
         break;
+      case "updateCursor":
+        console.log("updateCursor", msg);
+        break;
       default:
         throw new Error(
-          `Received unsupported response message type from server: ${msg}`
+          `Received unsupported response message type from server: ${JSON.stringify(msg)}`
         );
     }
   }


### PR DESCRIPTION
Adds logic for sharing cursor selection information across multiple clients. The client/UI doesn't take advantage of this yet.